### PR TITLE
Uit 41 create dropdown menu

### DIFF
--- a/assets/styles/modules/_dropdowns.scss
+++ b/assets/styles/modules/_dropdowns.scss
@@ -5,42 +5,134 @@
 ////
 
 ///
-$msuxf-dropdown-width: 200px !default;
-///
-$msuxf-dropdown-event: focus !default;
-///
 $msuxf-dropdown-animation: fade !default;
+///
+$msuxf-dropdown-event: hover !default;
+///
+$msuxf-dropdown-position: left !default;
+///
+$msuxf-dropdown-style: true !default;
+///
+$msuxf-dropdown-width: toem(200px) !default;
+///
+$msuxf-dropdown-background-color: #000 !default;
+///
+$msuxf-dropdown-border-radius: $c-button-border-radius !default;
+///
+$msuxf-dropdown-padding: $c-button-padding !default;
+///
+$msuxf-dropdown-link-color: #fff !default;
 
-@mixin c-dropdown($width: $msuxf-dropdown-width, $event: $msuxf-dropdown-event, $animation: $msuxf-dropdown-animation) {
+/// This is a CSS dropdown component that handles different triggering events and animation styles.
+/// @param {string} $animation [fade] - Animation style in which the list is going to be shown. Accepted values: `fade`, `slide-down`, or `none`.
+/// @param {string} $event [hover] - Trigger event to show the list. Accepted values: `hover`, `focus`, or `none`.
+/// @param {string} $position [left] - List position once is visible. Accepted values: `left`, or `right`.
+/// @param {bool} $style [true] - Whether to include styles for the button and list or not.
+/// @example scss - Using the mixin
+///   @include c-dropdown(focus, fade, left, true);
+/// @example markup - HTML structure
+///   <div class="c-dropdown">
+///     <button class="button c-dropdown__button">Dropdown</button>
+///     <ul class="c-dropdown__items">
+///       <li><a href="#">First item</a></li>
+///       <li><a href="#">Second item</a></li>
+///       <li><a href="#">Third item</a></li>
+///     </nav>
+///   </div>
+
+@mixin c-dropdown($event: $msuxf-dropdown-event, $animation: $msuxf-dropdown-animation, $position: $msuxf-dropdown-position, $style: $msuxf-dropdown-style) {
   @if not index(focus hover, $event) {
     @error "Event must be either `focus` or `hover`.";
   }
-  @if not index(fade slide-down, $animation) {
-    @error "Animation must be either `fade` or `slide-down`.";
+  @if not index(fade slide-down none, $animation) {
+    @error "Animation must be either `fade`, `slide-down` or `none`.";
   }
-
-  @include c-button();
+  @if not index(left right, $position) {
+    @error "Position must be either `left` or `right`.";
+  }
+  @if type-of($style) != bool {
+    @error "Style must be either `true` or `false`.";
+  }
 
   .c-dropdown {
     position: relative;
     display: inline-block;
-    width: $width;
 
     &__items {
+      position: absolute;
+      #{$position}: 0;
+      z-index: 100;
       display: block;
+      overflow: hidden;
+      width: $msuxf-dropdown-width;
+      max-height: 0;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      opacity: 0;
+      visibility: hidden;
 
+      // Different transitions depending on the animation type
       @if $animation == fade {
-
+        transition: opacity $msuxf-transition-duration $msuxf-transition-timing;
       }
       @else if $animation == slide-down {
-
+        transition: max-height 0.75s ease-in-out; // Global variables not used here to improve interaction for max-height transition
       }
 
-      a {
-        display: block;
+      // If true, add styles to the list
+      @if $style == true {
+        padding: $msuxf-dropdown-padding;
+        border-radius: $msuxf-dropdown-border-radius;
+        background-color: $msuxf-dropdown-background-color;
+
+        a {
+          display: block;
+          color: $msuxf-dropdown-link-color;
+          opacity: 0.75;
+          transition: all $msuxf-transition-duration $msuxf-transition-timing;
+
+          &:hover {
+            padding-left: 5px;
+            opacity: 1;
+          }
+        }
+
+        li {
+          padding: 5px 0;
+        }
+      }
+    }
+
+    // If true, include styles for the button
+    @if $style == true {
+      @include c-button();
+
+      &__button {
+        margin-bottom: 3px;
+      }
+    }
+
+    // Trigger different events depending on the event parameter
+    @if $event == focus {
+      &__button {
+        &:#{$event} {
+          + .c-dropdown__items {
+            max-height: 1000px; // Random value to max-height can be animated as height property
+            visibility: visible;
+            opacity: 1;
+          }
+        }
+      }
+    }
+    @else if $event == hover {
+      &:#{$event} {
+        > .c-dropdown__items {
+          max-height: 1000px; // Random value to max-height can be animated as height property
+          visibility: visible;
+          opacity: 1;
+        }
       }
     }
   }
 }
-
-@include c-dropdown();

--- a/assets/styles/modules/_dropdowns.scss
+++ b/assets/styles/modules/_dropdowns.scss
@@ -1,0 +1,46 @@
+////
+/// Dropdown menu
+/// @group components
+/// @author MS
+////
+
+///
+$msuxf-dropdown-width: 200px !default;
+///
+$msuxf-dropdown-event: focus !default;
+///
+$msuxf-dropdown-animation: fade !default;
+
+@mixin c-dropdown($width: $msuxf-dropdown-width, $event: $msuxf-dropdown-event, $animation: $msuxf-dropdown-animation) {
+  @if not index(focus hover, $event) {
+    @error "Event must be either `focus` or `hover`.";
+  }
+  @if not index(fade slide-down, $animation) {
+    @error "Animation must be either `fade` or `slide-down`.";
+  }
+
+  @include c-button();
+
+  .c-dropdown {
+    position: relative;
+    display: inline-block;
+    width: $width;
+
+    &__items {
+      display: block;
+
+      @if $animation == fade {
+
+      }
+      @else if $animation == slide-down {
+
+      }
+
+      a {
+        display: block;
+      }
+    }
+  }
+}
+
+@include c-dropdown();

--- a/assets/styles/modules/_dropdowns.scss
+++ b/assets/styles/modules/_dropdowns.scss
@@ -54,6 +54,13 @@ $msuxf-dropdown-link-color: #fff !default;
     @error "Style must be either `true` or `false`.";
   }
 
+  // Placeholder to provide the active styling without repeating code
+  %c-dropdown--active {
+    max-height: 1000px; // Random value to max-height can be animated as height property
+    visibility: visible;
+    opacity: 1;
+  }
+
   .c-dropdown {
     position: relative;
     display: inline-block;
@@ -118,9 +125,7 @@ $msuxf-dropdown-link-color: #fff !default;
       &__button {
         &:#{$event} {
           + .c-dropdown__items {
-            max-height: 1000px; // Random value to max-height can be animated as height property
-            visibility: visible;
-            opacity: 1;
+            @extend %c-dropdown--active;
           }
         }
       }
@@ -128,9 +133,7 @@ $msuxf-dropdown-link-color: #fff !default;
     @else if $event == hover {
       &:#{$event} {
         > .c-dropdown__items {
-          max-height: 1000px; // Random value to max-height can be animated as height property
-          visibility: visible;
-          opacity: 1;
+          @extend %c-dropdown--active;
         }
       }
     }

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -44,6 +44,14 @@
   <!-- /End of Header -->
   <!-- Content -->
   <main role="main">
+    <div class="c-dropdown">
+      <button class="button">Dropdown</button>
+      <div class="c-dropdown__items">
+        <a href="">This is the first item</a>
+        <a href="">Second</a>
+        <a href="">And the 3rd</a>
+      </div>
+    </div>
   </main>
   <!-- /End of Content -->
   <!-- Footer -->

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -44,14 +44,6 @@
   <!-- /End of Header -->
   <!-- Content -->
   <main role="main">
-    <div class="c-dropdown">
-      <button class="button">Dropdown</button>
-      <div class="c-dropdown__items">
-        <a href="">This is the first item</a>
-        <a href="">Second</a>
-        <a href="">And the 3rd</a>
-      </div>
-    </div>
   </main>
   <!-- /End of Content -->
   <!-- Footer -->


### PR DESCRIPTION
## Background
_This is a relatively simple dropdown component that takes care of list menus depending on different triggering events as well as animations._
## Changes done
_Component can be configured to handle: `focus` or `hover` event, `fade`, `slide-down` or no animation to show the list, `left` or `right` position and the ability to include styles or not (to set them manually)._
## Pending to be done
_N/A._
## Notes
_I encourage the reviewers to pull the branch down and test the interactions._
## Mention
_ @UXdevs  uxdev@makingsense.com_