### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MS-UX-Development-Framework",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "Starter framework for UX Development projects",
   "homepage": "http://makingsense.com",
@@ -13,7 +13,8 @@
     "ux"
   ],
   "author": "Making Sense's UX Development team <hello@makingsense.com>",
-  "contributors": [{
+  "contributors": [
+    {
       "name": "Damián Muti",
       "email": "dmuti@makingsense.com"
     },
@@ -40,10 +41,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MakingSense/MSUIF.git"
+    "url": "https://github.com/MakingSense/MSUXF.git"
   },
   "devDependencies": {
-    "autoprefixer": "~6.7.2",
+    "autoprefixer": "~6.7.3",
+    "bower": "^1.8.0",
     "browser-sync": "~2.18.7",
     "css-mqpacker": "~5.0.1",
     "del": "~2.2.0",


### PR DESCRIPTION
## Background
_Bower wasn't a dependency in MSUXF, assuming a global bower install was made previously, failing to build on new environments, on the other hand NPM version of the package was 1.2.0, the repo was 1.1.1, this was confusing. 
Last but not least, the git url in the file was pointing to the old MSUIF repo_

## Changes done
- Bump version to 1.2.0
- Updated autoprefixer to 6.7.3
- Added Bower as a devDependency
- Fixed git repo url

## Pending to be done
_N/A_

## Notes
_N/A_

## Mention
@UXdevs