### PR TITLE
UDC-112 Sort CSS Media Queries

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ var gulp = require('gulp'),
   csso = require('gulp-csso'),
   // Require Css-MQpacker// Clean CSS
   mqpacker = require('css-mqpacker'),
+  sortCSSmq = require('sort-css-media-queries'),
   // Image optimization plugin
   imagemin = require('gulp-imagemin'),
   // Image optimization using Kraken API
@@ -90,7 +91,9 @@ var config = {
           'ie 9' //This is a Default Autoprefixer Config. In case that you need to add other browser support uncomment from above.
         ]
       }),
-      mqpacker()
+      mqpacker({
+        sort: sortCSSmq
+      })
     ]
   },
   // Sassdoc task options

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ var gulp = require('gulp'),
   csso = require('gulp-csso'),
   // Require Css-MQpacker// Clean CSS
   mqpacker = require('css-mqpacker'),
-  sortCSSmq = require('sort-css-media-queries'),
+  mqsorter = require('sort-css-media-queries'),
   // Image optimization plugin
   imagemin = require('gulp-imagemin'),
   // Image optimization using Kraken API
@@ -92,7 +92,7 @@ var config = {
         ]
       }),
       mqpacker({
-        sort: sortCSSmq
+        sort: mqsorter
       })
     ]
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "gulp-zip": "~4.0.0",
     "node-sass": "~4.5.3",
     "postcss-clean": "~1.0.3",
-    "sassdoc": "^2.3.0"
+    "sassdoc": "^2.3.0",
+    "sort-css-media-queries": "^1.3.3"
   },
   "main": "pdr",
   "engines": {


### PR DESCRIPTION
## Background
_By default css-mqpacker just sort the media queries declarations as mobile first way. Adding this plugin, we'll have the capability to sort automatically in both ways. Mobile-first or Desktop-first._

## Changes done
- Added dev dependency.
