### PR TITLE
[UDC-118] Issue with "gulp run" JS concatenation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -263,7 +263,7 @@ gulp.task('js:dist', function() {
   return gulp.src([config.folderAssets.js + '/**/*.js'])
     .pipe(sourcemaps.init())
     .pipe(concat('app.js', {
-      newLine: ';'
+      newLine: "\r\n;"
     }))
     .pipe(uglify())
     .pipe(sourcemaps.write('./'))
@@ -274,7 +274,7 @@ gulp.task('js:dist', function() {
 gulp.task('copy:vendors', function() {
   return gulp.src([config.folderAssets.js + '/vendors/*.js'])
     .pipe(concat('vendors.js', {
-      newLine: ';'
+      newLine: "\r\n;"
     }))
     .pipe(gulp.dest(config.folderDev.js));
 });
@@ -283,7 +283,7 @@ gulp.task('copy:vendors', function() {
 gulp.task('copy:js', ['copy:vendors'], function() {
   return gulp.src([config.folderAssets.js + '/*.js'])
     .pipe(concat('main.js', {
-      newLine: ';'
+      newLine: "\r\n;"
     }))
     .pipe(gulp.dest(config.folderDev.js));
 });


### PR DESCRIPTION
## Background
_When there was a js file ending with a line comment "//" the concatenation char ; was commented along with the first line of the next javascript resulting in a JS error._

## Changes done
* Added a line break to the concatenation string in JS files.

## Pending to be done
_N/A_

## Notes
_N/A_
