### PR TITLE
Fixed warnings on gulp build

### DIFF
--- a/assets/styles/helpers/_functions.scss
+++ b/assets/styles/helpers/_functions.scss
@@ -98,7 +98,7 @@
 }
 
 /// String URL encode function
-/// @param {string}
+/// @param {string} string
 /// @return {string} - URL encoded string
 @function url-encode($string) {
   $map: (

--- a/assets/styles/libs/sassy-cast/_SassyCast.scss
+++ b/assets/styles/libs/sassy-cast/_SassyCast.scss
@@ -107,7 +107,7 @@ $sc-constants: (
 /// @return {List}
 @function to-list($value) {
   $type: type-of($value);
-  
+
   // If the value is already a list, we can safely return it.
   @if ($type == 'list') {
     @return $value;
@@ -275,10 +275,10 @@ $sc-constants: (
 /// @access private
 /// @param {string} $string - string
 /// @return {Color | String} - string or hex color depending on the match
-/// @require {function} _hex-to-dec
+/// @require {function} _sc-hex-to-dec
 @function _sc-from-hex($string) {
   $string: to-lower-case($string);
-  $r: ''; 
+  $r: '';
   $g: '';
   $b: '';
   $hex: map-get($sc-constants, 'HEXADECIMAL_SPACE');
@@ -337,7 +337,7 @@ $sc-constants: (
 
   @for $i from 1 through str-length($value) {
     $character: str-slice($value, $i, $i);
-  
+
     // If the character is neither the part of the function name, nor a space or
     // a parenthese, we proceed further.
     @if not index($discarded-characters, $character) {
@@ -347,7 +347,7 @@ $sc-constants: (
         $current-channel-index: index($channel-keys, $current-channel);
         $current-channel: nth($channel-keys, $current-channel-index + 1);
       }
-  
+
       // If the current character is not a comma, it means it is part of the
       // value for the current channel and therefore should be saved.
       @else {
@@ -356,18 +356,18 @@ $sc-constants: (
       }
     }
   }
-  
+
   $hue: to-number(map-get($channels, 'h'));
   $saturation: to-number(map-get($channels, 's'));
   $lightness: to-number(map-get($channels, 'l'));
   $alpha: map-get($channels, 'a');
 
-  // If there is no alpha channel registered, return a classic hsl(..) call.  
+  // If there is no alpha channel registered, return a classic hsl(..) call.
   @if ($alpha == '') {
     @return hsl($hue, $saturation, $lightness);
   }
-  
-  // If there is a registered alpha channel, return a hsla(..) call.  
+
+  // If there is a registered alpha channel, return a hsla(..) call.
   @return hsla($hue, $saturation, $lightness, to-number($alpha));
 }
 
@@ -394,7 +394,7 @@ $sc-constants: (
         $current-channel-index: index($channel-keys, $current-channel);
         $current-channel: nth($channel-keys, $current-channel-index + 1);
       }
-  
+
       // If the current character is not a comma, it means it is part of the
       // value for the current channel and therefore should be saved.
       @else {
@@ -403,18 +403,18 @@ $sc-constants: (
       }
     }
   }
-  
+
   $red: to-number(map-get($channels, 'r'));
   $green: to-number(map-get($channels, 'g'));
   $blue: to-number(map-get($channels, 'b'));
   $alpha: map-get($channels, 'a');
-  
-  // If there is no alpha channel registered, return a classic hsl(..) call.  
+
+  // If there is no alpha channel registered, return a classic hsl(..) call.
   @if ($alpha == '') {
     @return rgb($red, $green, $blue);
   }
 
-  // If there is a registered alpha channel, return a rgba(..) call.    
+  // If there is a registered alpha channel, return a rgba(..) call.
   @return rgba($red, $green, $blue, to-number($alpha));
 }
 

--- a/assets/styles/modules/_buttons.scss
+++ b/assets/styles/modules/_buttons.scss
@@ -53,6 +53,9 @@ $c-button-border-radius: toem(5px) !default;
   }
 }
 
+///
+$mobile-menu-button-transition: $msuxf-transition-duration + ' ' + $msuxf-transition-timing !default;
+
 /// Mixin for generating the burguer-ish button used in mobile menus. This button is also transformed into an X when adding the <code>active</code> class to the element (as an indicator for closing the mobile menu).
 /// @param {size} $width - Total width of the button.
 /// @param {size} $height - Total height of the button.
@@ -70,7 +73,6 @@ $c-button-border-radius: toem(5px) !default;
 /// @todo Maybe adding different animations?
 
 @mixin c-mobile-menu-button($width, $height, $stroke, $color) {
-  $mobile-menu-button-transition: $msuxf-transition-duration + ' ' + $msuxf-transition-timing !default;
   $sin45: 0.70710678118; //sqrt(2)/2 = sin(45 deg)
   $cos45: $sin45;
   $offset-y: ($width * $sin45 - $height + $stroke) / 2;

--- a/assets/styles/modules/_buttons.scss
+++ b/assets/styles/modules/_buttons.scss
@@ -69,10 +69,8 @@ $c-button-border-radius: toem(5px) !default;
 /// </div>
 /// @todo Maybe adding different animations?
 
-///
-$mobile-menu-button-transition: $msuxf-transition-duration + ' ' + $msuxf-transition-timing !default;
-
 @mixin c-mobile-menu-button($width, $height, $stroke, $color) {
+  $mobile-menu-button-transition: $msuxf-transition-duration + ' ' + $msuxf-transition-timing !default;
   $sin45: 0.70710678118; //sqrt(2)/2 = sin(45 deg)
   $cos45: $sin45;
   $offset-y: ($width * $sin45 - $height + $stroke) / 2;


### PR DESCRIPTION
## Background
_There were some SassDoc warnings when building the project._

## Changes done
- Fixed SassDoc comments which caused the warnings.

## Notes
The warnings were:
```
» [WARNING] @parameter must at least have a name. Location: _functions.scss:100:102
» [WARNING] Annotation `parameter` is not allowed on comment from type `css` in `_buttons.scss:56:70`.
» [WARNING] Annotation `parameter` is not allowed on comment from type `css` in `_buttons.scss:56:70`.
» [WARNING] Annotation `parameter` is not allowed on comment from type `css` in `_buttons.scss:56:70`.
» [WARNING] Annotation `parameter` is not allowed on comment from type `css` in `_buttons.scss:56:70`.
» [WARNING] Annotation `parameter` is not allowed on comment from type `css` in `_buttons.scss:56:70`.
» [WARNING] Item `_sc-from-hex` requires `_hex-to-dec` from type `function` but this item doesn't exist.
```
Which ~~absolutely does not~~ has ~~anything~~ to do with my colaboration with the mixin `c-mobile-menu-button()` which I've added recently... At least not all warnings!