### PR TITLE
"gulp dist:zip" does not generates the zip file properly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -356,7 +356,7 @@ gulp.task('deploy', ['build'], function() {
 // Define Dist generation and zipping
 gulp.task('dist:zip', ['dist'], function() {
   var today = new Date();
-  return gulp.src(config.folderDist.base + '**/*')
+  return gulp.src(config.folderDist.base + '/**/*')
     .pipe(zip('deploy--' +
       today.getFullYear() + '-' +
       (today.getMonth() + 1) + '-' +

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -356,7 +356,7 @@ gulp.task('deploy', ['build'], function() {
 // Define Dist generation and zipping
 gulp.task('dist:zip', ['dist'], function() {
   var today = new Date();
-  return gulp.src(config.folderDist.base)
+  return gulp.src(config.folderDist.base + '**/*')
     .pipe(zip('deploy--' +
       today.getFullYear() + '-' +
       (today.getMonth() + 1) + '-' +


### PR DESCRIPTION
## Background
_When running `gulp dist:zip` the script generates an empty zip file_

## Changes done
- Changed source selector to properly grab all dest files when zipping.

## Notes
_N/A_